### PR TITLE
(misc) Exclude the .git directory when packaging

### DIFF
--- a/.pdkignore
+++ b/.pdkignore
@@ -1,0 +1,2 @@
+.git
+build


### PR DESCRIPTION
When building a package for the Puppet Forge, do not include the .git
directory.