### PR TITLE
(#9) Manage pxp-agent dependency on FreeBSD

### DIFF
--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -1,0 +1,3 @@
+---
+mcollective_agent_bolt_tasks::package_dependencies:
+  pxp-agent: "present"

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -8,5 +8,7 @@ defaults:
 hierarchy:
   - name: "plugin"
     path: "plugin.yaml"
+  - name: "os-specific"
+    path: "os/%{facts.os.family}.yaml"
   - name: "defaults"
     path: "defaults.yaml"


### PR DESCRIPTION
This dependency must be installed for bolt tasks to be runnable by
choria-server.

Fix #9

