### PR TITLE
Avoid clash between choria and task parameters

### DIFF
--- a/files/mcollective/application/tasks.rb
+++ b/files/mcollective/application/tasks.rb
@@ -36,7 +36,7 @@ module MCollective
                           :type => :boolean
 
         self.class.option :__environment,
-                          :arguments => ["--environment ENVIRONMENT"],
+                          :arguments => ["-E ENVIRONMENT"],
                           :description => "The environment to find tasks",
                           :default => "production",
                           :type => String
@@ -163,7 +163,7 @@ Examples:
                           :type => String
 
       self.class.option :__environment,
-                          :arguments => ["--environment ENVIRONMENT"],
+                          :arguments => ["-E ENVIRONMENT"],
                           :description => "The environment to find tasks",
                           :default => "production",
                           :type => String
@@ -394,7 +394,7 @@ Examples:
       end
 
       def extract_environment_from_argv
-        idx = ARGV.index("--environment")
+        idx = ARGV.index("-E")
 
         return "production" unless idx
 


### PR DESCRIPTION
In #13, an `--environment` parameter was added to choria to select which environment should be used to download a task files.  However, this conflicts with tasks which expect and `environment` parameter and break them.

Rename the environment selection option `-E` to avoid this issue: as a task name is always lowercase, this should not introduce any conflict.

Cc @treydock 